### PR TITLE
Response.php: Fix GET param name in generated URL

### DIFF
--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -367,7 +367,7 @@ class Response implements ResponseInterface
             // add parameters to URL redirection
             $parts = parse_url($url);
             $sep = isset($parts['query']) && !empty($parts['query']) ? '&' : '?';
-            $url .= $sep . http_build_query($this->parameters);
+            $url .= $sep . http_build_query($this->parameters, '', '&');
         }
 
         $this->addHttpHeaders(array('Location' =>  $url));


### PR DESCRIPTION
Updated the call to http_build_query to include $numeric_prefix = '', and $separator = '&'
This minor change fixes the issue where the get parameters name becomes 'amp;keyname' in $_GET instead of 'keyname'